### PR TITLE
Fix badly formatted PEM header in sample logs.config

### DIFF
--- a/python/ct/config/logs.config
+++ b/python/ct/config/logs.config
@@ -3,9 +3,14 @@ ctlog:{
   log_id:'pLkJkLQYWBSHuxOizGdwCjw1mAT5G9+443fNDsgN3BA='
   public_key_info:{
     type:ECDSA
-        pem_key:'-----BEGIN ECDSA PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0D'
-	'AQcDQgAEfahLEimAoz2t01p3uMziiLOl/fHTDM0YDOhBRuiBARsV4UvxG2LdNgoIGLrtCz'
-	'WE0J5APC2em4JlvR8EEEFMoA==\n-----END ECDSA PUBLIC KEY-----'
+    pem_key:
+    '-----BEGIN PUBLIC KEY-----\n'
+    'MFkwEwYHKoZIzj0CAQYIKoZIzj0D'
+    'AQcDQgAEfahLEimAoz2t01p3uMzi'
+    'iLOl/fHTDM0YDOhBRuiBARsV4Uvx'
+    'G2LdNgoIGLrtCzWE0J5APC2em4Jl'
+    'vR8EEEFMoA==\n'
+    '-----END PUBLIC KEY-----'
   }
 }
 


### PR DESCRIPTION
Since switching to the Python crypto library 'cryptography' the example logs.config file has broken the Python monitor.  'cryptography' is fussier about PEM headers.  The fix removes the word 'ECDSA' from the header of the example log, and reformats the file to tidy it up.